### PR TITLE
fix(ci+security): resolve CVEs, fix npm audit, build workspace packages in all test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,9 @@ jobs:
           retry_wait_seconds: 30
           command: npm ci --ignore-scripts
 
+      - name: Build workspace packages
+        run: npm run build -w packages/serval-core -w packages/mcp-client -w packages/mcp-http -w packages/mcp-runtime -w packages/mcp-stdio
+
       - name: Run fast tests with retry (shard ${{ matrix.shard }}/4)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
@@ -267,6 +270,9 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: npm ci --ignore-scripts
+
+      - name: Build workspace packages
+        run: npm run build -w packages/serval-core -w packages/mcp-client -w packages/mcp-http -w packages/mcp-runtime -w packages/mcp-stdio
 
       - name: Run snapshot regression suite
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
@@ -317,6 +323,9 @@ jobs:
           retry_wait_seconds: 30
           command: npm ci --ignore-scripts
 
+      - name: Build workspace packages
+        run: npm run build -w packages/serval-core -w packages/mcp-client -w packages/mcp-http -w packages/mcp-runtime -w packages/mcp-stdio
+
       - name: Setup Turbo cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -359,6 +368,9 @@ jobs:
           retry_wait_seconds: 30
           command: npm ci --ignore-scripts
 
+      - name: Build workspace packages
+        run: npm run build -w packages/serval-core -w packages/mcp-client -w packages/mcp-http -w packages/mcp-runtime -w packages/mcp-stdio
+
       - name: Run MCP HTTP task contract checks
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
@@ -390,6 +402,9 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: npm ci --ignore-scripts
+
+      - name: Build workspace packages
+        run: npm run build -w packages/serval-core -w packages/mcp-client -w packages/mcp-http -w packages/mcp-runtime -w packages/mcp-stdio
 
       - name: Run HTTP transport failover regression
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
@@ -684,10 +699,12 @@ jobs:
         run: npm run check:security-exceptions
 
       - name: Run security audit (fail on high/critical)
-        # continue-on-error: node-saml → xml-encryption → node-forge has unfixable high/critical
-        # vulns with no upstream fix. Re-evaluate when node-saml v4 stable ships.
-        continue-on-error: true
-        run: npm audit --audit-level=high
+        # Allowlisted CVEs (no fix available, unfixable transitive deps). See SECURITY_EXCEPTIONS.md.
+        # node-tar GHSAs via duckdb → node-gyp; GHSA-65ch-62r8-g69g via node-saml.
+        # Any NEW CVE not in this list will still fail CI.
+        run: >
+          npm audit --audit-level=high
+          --allow-ghsas GHSA-65ch-62r8-g69g,GHSA-34x7-hfp2-rc4v,GHSA-8qq5-rm4j-mr97,GHSA-83g3-92jg-28cx,GHSA-qffp-2rhf-9h96,GHSA-9ppj-qmqm-q256,GHSA-r6q2-hw4h-h46w,GHSA-vpq2-c234-7xj6
 
       - name: Run security audit (warn on moderate)
         run: npm audit --audit-level=moderate

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -101,6 +101,8 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Post-deploy smoke test
+        id: smoke
+        continue-on-error: true
         run: |
           echo "Waiting for deployment to stabilize..."
           sleep 15
@@ -109,8 +111,7 @@ jobs:
           HTTP_CODE=$(curl -sf -o /dev/null -w '%{http_code}' https://servalsheets.fly.dev/health/ready || echo "000")
           if [ "$HTTP_CODE" != "200" ]; then
             echo "❌ Health check failed: HTTP $HTTP_CODE"
-            echo "Rolling back..."
-            flyctl releases --json | head -1
+            echo "SMOKE_FAILED=true" >> $GITHUB_ENV
             exit 1
           fi
           echo "✅ Health check passed: HTTP $HTTP_CODE"
@@ -124,6 +125,15 @@ jobs:
           echo "Metrics endpoint: HTTP $HTTP_CODE"
 
           echo "✅ Smoke tests passed"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Rollback on smoke failure
+        if: env.SMOKE_FAILED == 'true'
+        run: |
+          echo "❌ Smoke test failed — rolling back to previous release..."
+          flyctl releases rollback --yes
+          exit 1
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -94,14 +94,12 @@ jobs:
         run: npm run check:security-exceptions
 
       - name: Run npm audit (fail on high/critical)
-        # SECURITY EXCEPTION: node-saml → xml-encryption → node-forge has unfixable high/critical
-        # vulns (GHSA-65ch-62r8-g69g etc.) with no upstream fix. xmldom patched via overrides.
-        # Re-evaluate when node-saml v4 stable ships.
-        # Exception tracked in SECURITY_EXCEPTIONS.md — review by 2026-06-26.
-        continue-on-error: true
-        run: |
-          echo "::warning::npm audit high-level check has continue-on-error due to node-saml transitive vuln (GHSA-65ch-62r8-g69g). See SECURITY_EXCEPTIONS.md."
+        # Allowlisted CVEs (no fix available, unfixable transitive deps). See SECURITY_EXCEPTIONS.md.
+        # GHSA-65ch-62r8-g69g: node-saml → node-forge. node-tar GHSAs via duckdb → node-gyp.
+        # Any NEW CVE not in this list will still fail CI.
+        run: >
           npm audit --audit-level=high
+          --allow-ghsas GHSA-65ch-62r8-g69g,GHSA-34x7-hfp2-rc4v,GHSA-8qq5-rm4j-mr97,GHSA-83g3-92jg-28cx,GHSA-qffp-2rhf-9h96,GHSA-9ppj-qmqm-q256,GHSA-r6q2-hw4h-h46w,GHSA-vpq2-c234-7xj6
 
       - name: Run npm audit (warn on moderate)
         run: npm audit --audit-level=moderate

--- a/fly.toml
+++ b/fly.toml
@@ -96,6 +96,8 @@ primary_region = "iad"  # IAD = Northern Virginia (low latency to Anthropic)
   size = "shared-cpu-1x"
   memory = "1gb"
   processes = ["app"]
+  kill_signal = "SIGTERM"
+  kill_timeout = "30s"
 
 [[mounts]]
   source = "servalsheets_data"
@@ -108,11 +110,6 @@ primary_region = "iad"  # IAD = Northern Virginia (low latency to Anthropic)
 [metrics]
   port = 3000
   path = "/metrics"
-
-# Graceful shutdown — allow in-flight MCP requests to complete
-[experimental]
-  kill_signal = "SIGTERM"
-  kill_timeout = "30s"
 
 # Deploy strategy: canary with automatic rollback
 [deploy]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "prebuild": "npm run build -w packages/serval-core",
+    "prebuild": "npm run build -w packages/serval-core -w packages/mcp-client -w packages/mcp-http -w packages/mcp-runtime -w packages/mcp-stdio",
     "build": "tsc && npm run generate:metadata",
     "build:docker": "npm run build --workspaces --if-present && tsc",
     "build:cli": "tsc && node dist/cli.js",
@@ -195,6 +195,12 @@
     "typescript": "^6.0.2",
     "vitest": "^4.1.4",
     "yaml": "^2.8.3"
+  },
+  "overrides": {
+    "xmldom": "npm:@xmldom/xmldom@^0.9.0",
+    "handlebars": "^4.7.9",
+    "diff": ">=8.0.3",
+    "protobufjs": "^7.5.5"
   },
   "workspaces": [
     "packages/mcp-client",


### PR DESCRIPTION
## Summary

- **4 CVEs patched** via `overrides`: `xmldom` (critical), `handlebars` (high), `diff` (moderate), `protobufjs` (critical — RCE via `@opentelemetry/sdk-node → @grpc/proto-loader`)
- **npm audit now uses `--allow-ghsas` allowlist** instead of blanket `continue-on-error: true` in both `ci.yml` and `security.yml` — new CVEs will fail CI, only documented unfixable ones pass
- **Workspace packages built before tests** in all 5 CI test jobs (`test-fast`, `snapshot-tests`, `test-integration`, `mcp-http-task-contract`, `http-transport-failover`) — fixes import failures from `packages/*/dist/`
- **`prebuild` script expanded** to build all 5 `@serval/*` packages (was only `serval-core`)
- **`fly.toml` `[experimental]` block deprecated** — moved `kill_signal`/`kill_timeout` to `[[vm]]` per current Fly.io docs
- **Fly deploy rollback wired up** — smoke test failure now actually calls `flyctl releases rollback --yes` (previously just called `exit 1` with no rollback)

## Files Changed

| File | Change |
|------|--------|
| `package.json` | Add `overrides` block with 4 CVE fixes; expand `prebuild` to all 5 packages |
| `package-lock.json` | Regenerated |
| `.github/workflows/ci.yml` | Replace `continue-on-error` with `--allow-ghsas`; add workspace build to 5 test jobs |
| `.github/workflows/security.yml` | Replace `continue-on-error` with `--allow-ghsas` allowlist |
| `.github/workflows/fly-deploy.yml` | Add actual rollback step on smoke failure |
| `fly.toml` | Move deprecated `[experimental]` to `[[vm]]` |

## Test plan

- [x] `npm audit --audit-level=high --allow-ghsas ...` exits 0
- [x] No merge conflicts (clean branch from latest main)
- [x] All changes are infrastructure/CI only — no source code changes

https://claude.ai/code/session_015SSZgj8k7X7kvvLAKCbfLn