### PR TITLE
fix(tests): use os.tmpdir() in token-store tests to satisfy path validator

### DIFF
--- a/tests/services/token-store.test.ts
+++ b/tests/services/token-store.test.ts
@@ -7,8 +7,9 @@ import { EncryptedFileTokenStore } from '../../src/services/token-store.js';
 import { randomBytes } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { tmpdir } from 'os';
 
-const tmpDir = path.join(process.cwd(), 'tests', '.tmp');
+const tmpDir = path.join(tmpdir(), 'servalsheets-test-tokens');
 const tokenFile = path.join(tmpDir, 'tokens.enc');
 
 describe('EncryptedFileTokenStore', () => {


### PR DESCRIPTION
## Summary

- `sanitizeTokenStorePath()` (added in `src/utils/auth-paths.ts`) restricts token store paths to `homedir()` or `/tmp` as a path-traversal guard.
- In containerised CI the process runs as **root** (`homedir = /root`), while `process.cwd()` resolves to `/home/user/servalsheets`, so the old `tests/.tmp` path fell outside every allowed root and raised a `ValidationError`.
- Fix: switch the test's temp dir from `path.join(process.cwd(), 'tests', '.tmp')` to `path.join(os.tmpdir(), 'servalsheets-test-tokens')`, which is always within `/tmp` regardless of which user runs the tests.

## Test plan
- [ ] `npx vitest run tests/services/token-store.test.ts` → 2 passed
- [ ] `npm run gates` (typecheck + test:run + check:drift) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SxFDipjzfqNKnq6sB3a6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_012SxFDipjzfqNKnq6sB3a6Q)_